### PR TITLE
Added option to make gamemode voting default

### DIFF
--- a/pam_gamemode_voting/lua/pam/server/extensions/gamemode.lua
+++ b/pam_gamemode_voting/lua/pam/server/extensions/gamemode.lua
@@ -11,7 +11,7 @@ function PAM_EXTENSION:OnInitialize()
 	PAM.RegisterTypeHandler("gamemode", function(option)
 		PAM.ChangeGamemode(option)
 		PAM.Cancel()
-		PAM.Start()
+		PAM.Start("map")
 	end)
 end
 

--- a/pam_gamemode_voting/lua/pam/server/extensions/gamemode.lua
+++ b/pam_gamemode_voting/lua/pam/server/extensions/gamemode.lua
@@ -9,6 +9,7 @@ local default_votetype_setting = setting_namespace:AddSetting("gamemode_default_
 
 function PAM_EXTENSION:OnInitialize()
 	PAM.RegisterTypeHandler("gamemode", function(option)
+		self.vote_ended = true
 		PAM.ChangeGamemode(option)
 		PAM.Cancel()
 		PAM.Start("map")
@@ -17,6 +18,7 @@ end
 
 function PAM_EXTENSION:RegisterSpecialOptions()
 	if PAM.vote_type ~= "map" then return end
+	if self.vote_ended then return end
 
 	PAM.RegisterOption("change_gamemode", function()
 		PAM.Cancel()

--- a/pam_gamemode_voting/lua/pam/server/extensions/gamemode.lua
+++ b/pam_gamemode_voting/lua/pam/server/extensions/gamemode.lua
@@ -7,16 +7,20 @@ local vote_length_setting = setting_namespace:AddSetting("vote_length", pacoman.
 local blacklist_setting = setting_namespace:AddSetting("blacklist", pacoman.TYPE_STRING, "base", "Gamemodes that are listed here won't be available.")
 local default_votetype_setting = setting_namespace:AddSetting("gamemode_default_votetype", pacoman.TYPE_BOOLEAN, false, "Gamemode voting becomes the default votetype")
 
+function PAM_EXTENSION:OnInitialize()
+	PAM.RegisterTypeHandler("gamemode", function(option)
+		PAM.ChangeGamemode(option)
+		PAM.Cancel()
+		PAM.Start()
+	end)
+end
+
 function PAM_EXTENSION:RegisterSpecialOptions()
 	if PAM.vote_type ~= "map" then return end
 
 	PAM.RegisterOption("change_gamemode", function()
 		PAM.Cancel()
-		PAM.Start("gamemode", vote_length_setting:GetActiveValue(), function(option)
-			PAM.ChangeGamemode(option)
-			PAM.Cancel()
-			PAM.Start()
-		end)
+		PAM.Start("gamemode")
 	end)
 end
 
@@ -36,4 +40,10 @@ end
 
 function PAM_EXTENSION:GetDefaultVoteType()
 	if default_votetype_setting:GetActiveValue() then return "gamemode" end
+end
+
+function PAM_EXTENSION:GetVoteLength(vote_type)
+	if vote_type == "gamemode" then
+		return vote_length_setting:GetActiveValue()
+	end
 end

--- a/pam_gamemode_voting/lua/pam/server/extensions/gamemode.lua
+++ b/pam_gamemode_voting/lua/pam/server/extensions/gamemode.lua
@@ -5,6 +5,7 @@ PAM_EXTENSION.enabled = true
 local setting_namespace = PAM.setting_namespace:AddChild(name)
 local vote_length_setting = setting_namespace:AddSetting("vote_length", pacoman.TYPE_INTEGER, 30, "The length of the gamemode voting time in seconds.")
 local blacklist_setting = setting_namespace:AddSetting("blacklist", pacoman.TYPE_STRING, "base", "Gamemodes that are listed here won't be available.")
+local default_votetype_setting = setting_namespace:AddSetting("gamemode_default_votetype", pacoman.TYPE_BOOLEAN, false, "Gamemode voting becomes the default votetype")
 
 function PAM_EXTENSION:RegisterSpecialOptions()
 	if PAM.vote_type ~= "map" then return end
@@ -31,4 +32,8 @@ function PAM_EXTENSION:RegisterOptions()
 
 		PAM.RegisterOption(gamemode_table.name)
 	end
+end
+
+function PAM_EXTENSION:GetDefaultVoteType()
+	if default_votetype_setting:GetActiveValue() then return "gamemode" end
 end


### PR DESCRIPTION
This PR is on par with my PR on the partly-adequate-mapvote repo.
It adds an option to make gamemode voting the default, also makes it so the callback for the type is registered in a table instead of being provided by a parameter.